### PR TITLE
Move SonarCloud scan to an individual job

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -51,6 +51,7 @@ jobs:
       - name: Adjust coverage source path
         run: sed -i "s+$PWD/++g" coverage.xml
       - name: SonarCloud Scan
+        if: env.SONAR_TOKEN != null
         uses: sonarsource/sonarcloud-github-action@master
         with:
           args: >

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -30,15 +30,34 @@ jobs:
       - name: Test with pytest
         run: |
           pytest --cov --cov-report term --cov-report xml --junitxml=xunit-result.xml
-      - name: Run SonarCloud scan
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10' && env.SONAR_TOKEN != null
+      - uses: actions/upload-artifact@v3
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
+        with:
+          name: coverage-report
+          path: |
+            coverage.xml
+            xunit-result.xml
+
+  sonar-cloud:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull coverage report
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage-report
+          path: ${{ github.workspace }}
+      - name: Adjust coverage source path
+        run: sed -i "s+$PWD/++g" coverage.xml
+      - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         with:
           args: >
             -Dsonar.projectKey=max-test
             -Dsonar.organization=max-test
             -Dsonar.host.url=https://sonarcloud.io
-            -Dsonar.python.version="${{ matrix.python-version }}"
+            -Dsonar.python.version="3.10"
             -Dsonar.sources=gc_meox_tms/
             -Dsonar.tests=tests/
             -Dsonar.python.coverage.reportPaths=coverage.xml

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -55,8 +55,8 @@ jobs:
         uses: sonarsource/sonarcloud-github-action@master
         with:
           args: >
-            -Dsonar.projectKey=max-test
-            -Dsonar.organization=max-test
+            -Dsonar.projectKey=gc_derivatization
+            -Dsonar.organization=RECETOX
             -Dsonar.host.url=https://sonarcloud.io
             -Dsonar.python.version="3.10"
             -Dsonar.sources=gc_meox_tms/


### PR DESCRIPTION
* move sonarcloud check to a job that depends on matrix build
* add step to edit source path in report xml with `sed`
* make matrix build write coverage artifacts; sonarcloud reads these artifacts